### PR TITLE
prevent default when trying to move zoom section

### DIFF
--- a/src/InnerImageZoom/InnerImageZoom.vue
+++ b/src/InnerImageZoom/InnerImageZoom.vue
@@ -115,9 +115,9 @@
             load: handleLoad,
             touchstart: handleDragStart,
             touchend: handleDragEnd,
-            mousedown: handleDragStart,
             mouseup: handleDragEnd
           }"
+          v-on:mousedown.prevent="handleDragStart"
         />
 
         <button


### PR DESCRIPTION
I found problem when you trying to move zoomed section on some browsers(Firefox...) if using moveType "drag". 
Grab pointer move whole image instead of moving through the image.
This pull request will prevent to grab whole image and allow you to move through the image.