### PR TITLE
Added missing Alt tag for zoomed image

### DIFF
--- a/src/InnerImageZoom/InnerImageZoom.vue
+++ b/src/InnerImageZoom/InnerImageZoom.vue
@@ -71,7 +71,7 @@
           <div class="iiz__zoom-portal">
             <img
               class="iiz__zoom-img"
-              alt=""
+              v-bind:alt="alt"
               :draggable="false"
               v-bind:class="{ 'iiz__zoom-img--visible': isZoomed }"
               v-bind:style="{


### PR DESCRIPTION
It was hardcoded as empty for some reason.